### PR TITLE
Fixed issue with last caller not populating

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -144,7 +144,7 @@ function blacklist_blacklist_last($fc) {
 	$ext->add($id, $c, '', new ext_answer);
 	$ext->add($id, $c, '', new ext_macro('user-callerid'));
 	$ext->add($id, $c, '', new ext_wait(1));
-	$ext->add($id, $c, '', new ext_setvar('lastcaller', '${DB(CALLTRACE/${CALLERID(number)})}'));
+        $ext->add($id, $c, '', new ext_setvar('lastcaller', '${DB(CALLTRACE/${AMPUSER})}'));
 	$ext->add($id, $c, '', new ext_gotoif('$[ $[ "${lastcaller}" = "" ] | $[ "${lastcaller}" = "unknown" ] ]', 'noinfo'));
  	$ext->add($id, $c, '', new ext_playback('privacy-to-blacklist-last-caller&telephone-number'));
 	$ext->add($id, $c, '', new ext_saydigits('${lastcaller}'));


### PR DESCRIPTION
When dialing *32 the last caller would not populate a phone number. 